### PR TITLE
Fix broken dependency / Add functions / Make it work with Go 1.11.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,14 @@ The formatting options are:
     lower    | lowercase       : all lowercase letters
     cap      | capitalize      : uppercase first letter
     decap    | decapitalize    : lowercase first letter
-    start    | start-case      : uppercase the first letter of each word
-    word     | word-only       : remove all non-word letters (only a-zA-Z0-9_)
-    Camel    | upper-camel     : upper camel case (start-case, word-only)
-    camel    | lower-camel     : lower camel case (start-case, word-only, decapitalize)
+    space    |                 : replace all non-word letters (only a-zA-Z0-9) with a whitespace
+    start    |                 : uppercase the first letter of each word
+    word     |                 : remove all non-word letters (only a-zA-Z0-9_)
+    Camel    |                 : upper camel case (start-case, word-only)
+    camel    |                 : lower camel case (start-case, word-only, decapitalize)
     hyphen   | hyphenate       : replace spaces with hyphens
     norm     | normalize       : all lowercase with hyphens (lowercase, hyphenate)
-    snake    | snake-case      : replace spaces and dots with underscores
-    packaged | package-dir     : replace dots with slashes (net.databinder -> net/databinder)
-    random   | generate-random : appends random characters to the given string
+    snake    |                 : replace spaces and dots with underscores
+    package  |                 : replace spaces with dots
+    packaged |                 : replace dots with slashes (net.databinder -> net/databinder)
+    random   |                 : appends random characters to the given string

--- a/template/functions.go
+++ b/template/functions.go
@@ -23,10 +23,11 @@
 package template
 
 import (
-	"code.google.com/p/go-uuid/uuid"
 	"regexp"
 	"strings"
 	text_template "text/template"
+
+	"github.com/pborman/uuid"
 )
 
 var funcMap = text_template.FuncMap{

--- a/template/functions.go
+++ b/template/functions.go
@@ -37,7 +37,7 @@ var funcMap = text_template.FuncMap{
 	"lowercase":       Lower,
 	"start":           Start,
 	"word":            Word,
-	"word-only":       Word,
+	"word_only":       Word,
 	"camel":           CamelLower,
 	"Camel":           Camel,
 	"cap":             Capitalize,
@@ -47,11 +47,11 @@ var funcMap = text_template.FuncMap{
 	"normalize":       Normalize,
 	"norm":            Normalize,
 	"snake":           Snake,
-	"snake-case":      Snake,
+	"snake_case":      Snake,
 	"packaged":        Packaged,
-	"packaged-case":   Packaged,
+	"packaged_case":   Packaged,
 	"random":          Random,
-	"generate-random": Random,
+	"generate_random": Random,
 }
 
 var (

--- a/template/functions.go
+++ b/template/functions.go
@@ -31,31 +31,30 @@ import (
 )
 
 var funcMap = text_template.FuncMap{
-	"upper":           Upper,
-	"uppercase":       Upper,
-	"lower":           Lower,
-	"lowercase":       Lower,
-	"start":           Start,
-	"word":            Word,
-	"word_only":       Word,
-	"camel":           CamelLower,
-	"Camel":           Camel,
-	"cap":             Capitalize,
-	"capitalize":      Capitalize,
-	"hyphen":          Hyphenate,
-	"hyphenate":       Hyphenate,
-	"normalize":       Normalize,
-	"norm":            Normalize,
-	"snake":           Snake,
-	"snake_case":      Snake,
-	"packaged":        Packaged,
-	"packaged_case":   Packaged,
-	"random":          Random,
-	"generate_random": Random,
+	"upper":      Upper,
+	"uppercase":  Upper,
+	"lower":      Lower,
+	"lowercase":  Lower,
+	"start":      Start,
+	"word":       Word,
+	"space":      Space,
+	"camel":      CamelLower,
+	"Camel":      Camel,
+	"cap":        Capitalize,
+	"capitalize": Capitalize,
+	"hyphen":     Hyphenate,
+	"hyphenate":  Hyphenate,
+	"normalize":  Normalize,
+	"norm":       Normalize,
+	"snake":      Snake,
+	"package":    Package,
+	"packaged":   Packaged,
+	"random":     Random,
 }
 
 var (
 	wordRe       = regexp.MustCompile(`\W`)
+	wordUnderRe  = regexp.MustCompile(`[\W_]+`)
 	whitespaceRe = regexp.MustCompile(`\s`)
 	dotRe        = regexp.MustCompile(`\.`)
 	snakeRe      = regexp.MustCompile(`\.|\s`)
@@ -123,6 +122,14 @@ func Normalize(value string) string {
 
 func Hyphenate(value string) string {
 	return whitespaceRe.ReplaceAllString(value, "-")
+}
+
+func Space(value string) string {
+	return wordUnderRe.ReplaceAllString(value, " ")
+}
+
+func Package(value string) string {
+	return whitespaceRe.ReplaceAllString(value, ".")
 }
 
 func Packaged(value string) string {

--- a/template/functions_test.go
+++ b/template/functions_test.go
@@ -23,8 +23,9 @@
 package template
 
 import (
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestCapitalize(t *testing.T) {
@@ -60,6 +61,18 @@ func TestDecapitalize(t *testing.T) {
 
 	Convey("I can #Capitalize a string of length 1", t, func() {
 		So(Decapitalize("H"), ShouldEqual, "h")
+	})
+}
+
+func TestSpace(t *testing.T) {
+	Convey("#Space replaces non words or underscore with spaces", t, func() {
+		So(Space("com-loyal3_foo"), ShouldEqual, "com loyal3 foo")
+	})
+}
+
+func TestPackage(t *testing.T) {
+	Convey("#Package replaces spaces with dots", t, func() {
+		So(Package("com loyal3 foo"), ShouldEqual, "com.loyal3.foo")
 	})
 }
 


### PR DESCRIPTION
- broken dependency to `code.google.com/p/go-uuid/uuid`
- new functions `space` & `package`
- `-` symbol is not allowed in func names for `template` package